### PR TITLE
Possibility to pass video constraints to getUserMedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,38 @@ var player = videojs("myVideo",
 });
 ```
 
+It is also possible to use `getUserMedia` video constraints. For example:
+
+```javascript
+var player = videojs("myVideo",
+{
+    controls: true,
+    loop: false,
+    width: 320,
+    height: 240,
+    plugins: {
+        record: {
+            image: false,
+            audio: false,
+            video: {
+                width: 1280,
+                height: 720
+            },
+            maxLength: 5
+        }
+    }
+});
+```
+
+This will set the resolution to `1280x720` if the camera supports it.
+
 The available options for this plugin are:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `image` | boolean | `false` | Create single snapshot image. |
 | `audio` | boolean | `false` | Include audio in the recorded clip. |
-| `video` | boolean | `false` | Include video in the recorded clip. |
+| `video` | boolean/array | `false` | Include video in the recorded clip. |
 | `animation` | boolean | `false` | Animated GIF. |
 | `maxLength` | float | `10` | Maximum length of the recorded clip. |
 | `audioEngine` | string | `recordrtc` | Audio recording library to use. Legal values are `recordrtc` and `libvorbis.js`. |

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -276,7 +276,7 @@
     {
         /**
          * The constructor function for the class.
-         * 
+         *
          * @param {videojs.Player|Object} player
          * @param {Object} options Player options.
          */
@@ -478,7 +478,7 @@
                     // setup camera
                     this.mediaType = {
                         audio: false,
-                        video: true
+                        video: this.recordVideo
                     };
                     this.getUserMedia(
                         this.mediaType,
@@ -490,7 +490,7 @@
                     // setup camera and microphone
                     this.mediaType = {
                         audio: true,
-                        video: true
+                        video: this.recordVideo
                     };
                     this.getUserMedia(
                         this.mediaType,
@@ -508,7 +508,7 @@
                     };
                     this.getUserMedia({
                             audio: false,
-                            video: true
+                            video: this.recordVideo
                         },
                         this.onDeviceReady.bind(this),
                         this.onDeviceError.bind(this));
@@ -1101,7 +1101,7 @@
 
         /**
          * Start loading data.
-         * 
+         *
          * @param {String|Blob|File} url Either the URL of the media file,
          *     a Blob or a File object.
          */
@@ -1250,7 +1250,7 @@
         },
 
         /**
-         * 
+         *
          */
         startVideoPreview: function()
         {
@@ -1366,10 +1366,10 @@
 
         /**
          * Format seconds as a time string, H:MM:SS, M:SS or M:SS:MMM.
-         * 
+         *
          * Supplying a guide (in seconds) will force a number of leading zeros
          * to cover the length of the guide.
-         * 
+         *
          * @param {Number} seconds Number of seconds to be turned into a string
          * @param {Number} guide Number (in seconds) to model the string after
          * @return {String} Time formatted as H:MM:SS, M:SS or M:SS:MMM.


### PR DESCRIPTION
I added the possibility to specify constraints for video. For example:

```javascript
var player = videojs("myVideo",
{
    plugins: {
        record: {
            audio: true,
            video: {
                width: 1280,
                height: 720
            },
            maxLength: 5
        }
    }
});
```