### PR TITLE
Fixed: Webpack compatability

### DIFF
--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -3,7 +3,7 @@
     if (typeof define === 'function' && define.amd)
     {
         // AMD. Register as an anonymous module.
-        define(['videojs'], factory);
+        define(['video.js'], factory);
     }
     else if (typeof module === 'object' && module.exports)
     {


### PR DESCRIPTION
When using Webpack Video.js must be referenced as 'video.js' rather than 'videos'.
