### PR TITLE
js garbage collection and hide playback

### DIFF
--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -1292,6 +1292,17 @@
             this._recording = false;
             this._processing = false;
             this._deviceActive = false;
+
+        },
+
+        /**
+         * Release variables for js garbage collection and hide playback button
+         */
+        restore: function()
+        {
+            if (this.mediaURL)  URL.revokeObjectURL(this.mediaURL);
+            this.recordedData = null;
+            this.player().controlBar.playToggle.hide();
         },
 
         /**


### PR DESCRIPTION
On Chrome, xhr stalls once file size reaches 500mb; create a restore function to release variables and therefore able to process further re-takes