### PR TITLE
Taking into account asnyc stream loading before playing media

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,14 @@ videojs-record changelog
 - Bump required version for recordrtc to 5.4.2 for `timeSlice` support
 - Fix CSS styling for video.js 6.0 and newer (#149)
 
+1.6.3 - 2017/06/22
+------------------
+
+- onDeviceReady handler now plays the media stream after it's actually loaded (#154)
+- 'deviceReady' event is now triggered after media stream is actually loaded and played.
+- start method now starts recording after media stream's actually loaded.
+- 'startRecord' event is now triggered after media stream is actually loaded and played.
+
 
 1.6.2 - 2017/05/27
 ------------------

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -910,6 +910,7 @@
                     URL.revokeObjectURL(this.streamURL);
                 }
                 this.streamURL = URL.createObjectURL(this.stream);
+
                 // start stream
                 this.load(this.streamURL);
 

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -1002,44 +1002,62 @@
                 }
 
                 // start recording
-                if (this.getRecordType() !== this.IMAGE_ONLY)
+                switch (this.getRecordType())
                 {
-                    // startVideoPreview loaded media stream on video element, so
-                    // we must wait until it's actually loaded to start recording
-                    var self = this;
-                    this.player().one('loadedmetadata', function()
-                    {
-                        // register starting point
-                        self.paused = false;
-                        self.pauseTime = self.pausedTime = 0;
-                        self.startTime = new Date().getTime();
-
-                        // start countdown
-                        self.countDown = self.setInterval(
-                            self.onCountDown.bind(self), 100);
-
-                        // cleanup previous recording
-                        if (self.engine !== undefined)
-                        {
-                            self.engine.dispose();
-                        }
-
-                        // start recording stream
-                        self.engine.start();
+                    case this.IMAGE_ONLY:
+                        // create snapshot
+                        this.createSnapshot();
 
                         // notify UI
-                        self.player().trigger('startRecord');
-                    });
-                }
-                else
-                {
-                    // create snapshot
-                    this.createSnapshot();
+                        this.player().trigger('startRecord');
+                        break;
 
-                    // notify UI
-                    this.player().trigger('startRecord');
+                    case this.VIDEO_ONLY:
+                    case this.AUDIO_VIDEO:
+                    case this.ANIMATION:
+                        // wait for media stream on video element to actually load
+                        var self = this;
+                        this.player().one('loadedmetadata', function()
+                        {
+                            // start actually recording process.
+                            self.startRecording();
+                        });
+                        break;
+
+                    default:
+                        // all resources have already loaded, so we can start recording right away.
+                        this.startRecording();
+                        break;
                 }
             }
+        },
+
+        /**
+         * Start recording.
+         * @private
+         */
+        startRecording: function()
+        {
+            // register starting point
+            this.paused = false;
+            this.pauseTime = this.pausedTime = 0;
+            this.startTime = new Date().getTime();
+
+            // start countdown
+            this.countDown = this.setInterval(
+                this.onCountDown.bind(this), 100);
+
+            // cleanup previous recording
+            if (this.engine !== undefined)
+            {
+                this.engine.dispose();
+            }
+
+            // start recording stream
+            this.engine.start();
+
+            // notify UI
+            this.player().trigger('startRecord');
         },
 
         /**


### PR DESCRIPTION
Opening the camera streaming now waits for stream to load (asynchronously) in the video element before performing corresponding actions.

This fixes issue #154 where streaming was frozen in chrome android, as well as start the recording at the right time.