### PR TITLE
Update getInternalRecorder to verify that internal is defined

### DIFF
--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -1397,7 +1397,9 @@ class Record extends Plugin {
         }
 
         let maxFileSizeReached = false;
-        internal = internal.getInternalRecorder();
+        if (internal) {
+            internal = internal.getInternalRecorder();
+        }
 
         if ((internal instanceof MediaStreamRecorder) === true) {
             this.player.recordedData = internal.getArrayOfBlobs();


### PR DESCRIPTION
fixes #300

When resetting and restarting the player the timeslicer breaks (only on the last time slice).  This should fix that.