### PR TITLE
Use ES export syntax instead of commonjs

### DIFF
--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -1565,6 +1565,4 @@ if (videojs.getPlugin('record') === undefined) {
 }
 
 // export plugin
-module.exports = {
-    Record
-};
+export {Record};


### PR DESCRIPTION
Not sure whether there is a specific reason to use a commonjs export while all imports use the ES module syntax.

This is causing problems when bundling this with rollup: you'd usually use `rollup-plugin-commonjs` to resolve commonjs modules and their exports. This plugin ignores files which contain the ES module syntax. This will then lead to some error like `ReferenceError: module is not defined` because the `module.exports` line is never touched by rollup and ends up being in the browser bundle.
