### PR TITLE
fix autostop error when max file size was reached

### DIFF
--- a/src/js/engine/record-rtc.js
+++ b/src/js/engine/record-rtc.js
@@ -242,7 +242,7 @@ class RecordRTCEngine extends RecordEngine {
 
         // automatically stop when max file size was reached
         if (maxFileSizeReached) {
-            this.player().stop();
+            this.player().record().stop();
         }
     }
 }


### PR DESCRIPTION
Fix error when maxFileSize is enable.

![Screen Shot 2020-02-28 at 15 45 55](https://user-images.githubusercontent.com/40213497/75595483-79bc9e80-5a41-11ea-9b5d-d4b97ab241d8.png)
