### PR TITLE
handle 'abort' errors in ffmpeg.js plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 4.1.0 - unreleased
 
+- ffmpeg.js plugin: handle `abort` errors (#481)
 - Bump required version for webrtc-adapter to 7.6.1
 
 

--- a/src/js/plugins/ffmpegjs-plugin.js
+++ b/src/js/plugins/ffmpegjs-plugin.js
@@ -164,7 +164,8 @@ class FFmpegjsEngine extends ConvertEngine {
             case 'exit':
                 break;
 
-            // error occured
+            // FFmpeg terminated abnormally (e.g. out of memory, wasm error)
+            case 'abort':
             case 'error':
                 this.player().trigger('error', msg.data);
                 break;


### PR DESCRIPTION
refs #481 