### PR TITLE
Fix for IMAGE_ONLY mode - stretched output in player

### DIFF
--- a/examples/image-only-odd-dimensions.html
+++ b/examples/image-only-odd-dimensions.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Image-only Example - Record Plugin for Video.js</title>
+  <title>Image-only Example (Odd Dimensions) - Record Plugin for Video.js</title>
 
   <link href="../node_modules/video.js/dist/video-js.min.css" rel="stylesheet">
   <link href="../dist/css/videojs.record.css" rel="stylesheet">
@@ -28,8 +28,8 @@
 /* eslint-disable */
 var options = {
     controls: true,
-    width: 640,
-    height: 360,
+    width: 1080,
+    height: 1920,
     fluid: false,
     bigPlayButton: false,
     controlBar: {

--- a/examples/image-only-odd-dimensions.html
+++ b/examples/image-only-odd-dimensions.html
@@ -28,8 +28,8 @@
 /* eslint-disable */
 var options = {
     controls: true,
-    width: 1080,
-    height: 1920,
+    width: 320,
+    height: 640,
     fluid: false,
     bigPlayButton: false,
     controlBar: {
@@ -40,7 +40,7 @@ var options = {
         record: {
           audio: false,
           image: {
-            width: 1920 ,
+            width: 1920,
             height: 1080
           },
           frameWidth: 1920,

--- a/examples/image-only-odd-dimensions.html
+++ b/examples/image-only-odd-dimensions.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Image-only Example - Record Plugin for Video.js</title>
+
+  <link href="../node_modules/video.js/dist/video-js.min.css" rel="stylesheet">
+  <link href="../dist/css/videojs.record.css" rel="stylesheet">
+  <link href="assets/css/examples.css" rel="stylesheet">
+
+  <script src="../node_modules/video.js/dist/video.min.js"></script>
+  <script src="../node_modules/webrtc-adapter/out/adapter.js"></script>
+
+  <script src="../dist/videojs.record.js"></script>
+
+  <style>
+  /* change player background color */
+  #myImage {
+      background-color: #efc3e6;
+  }
+  </style>
+</head>
+<body>
+
+<video id="myImage" playsinline class="video-js vjs-default-skin"></video>
+
+<script>
+/* eslint-disable */
+var options = {
+    controls: true,
+    width: 640,
+    height: 360,
+    fluid: false,
+    bigPlayButton: false,
+    controlBar: {
+        volumePanel: false,
+        fullscreenToggle: false
+    },
+    plugins: {
+        record: {
+          audio: false,
+          image: {
+            width: 1920 ,
+            height: 1080
+          },
+          frameWidth: 1920,
+          frameHeight: 1080,
+        //   image: true,
+          debug: true,
+          imageOutputType: "dataURL",
+          imageOutputFormat: "image/png",
+          imageOutputQuality: 0.92,
+      }
+    }
+};
+
+var player = videojs('myImage', options, function() {
+    // print version information at startup
+    var msg = 'Using video.js ' + videojs.VERSION +
+        ' with videojs-record ' + videojs.getPluginVersion('record');
+    videojs.log(msg);
+});
+
+// error handling
+player.on('deviceError', function() {
+    console.warn('device error:', player.deviceErrorCode);
+});
+
+player.on('error', function(element, error) {
+    console.error(error);
+});
+
+// snapshot is available
+player.on('finishRecord', function() {
+    // the blob object contains the image data that
+    // can be downloaded by the user, stored on server etc.
+
+    console.log('snapshot ready: ', player.recordedData);
+});
+
+player.on('retry', function() {
+  console.log('retry');
+});
+</script>
+
+</body>
+</html>

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -52,7 +52,7 @@ class Record extends Plugin {
             let retval = this.techGet_('play');
             // silence errors (unhandled promise from play)
             if (retval !== undefined && typeof retval.then === 'function') {
-                retval.then(null, (e) => {});
+                retval.then(null, (e) => { });
             }
             return retval;
         };
@@ -1578,11 +1578,11 @@ class Record extends Plugin {
         this.player.el().firstChild.style.display = 'block';
     }
 
-  /**
-     * Capture frame from camera and copy data to canvas.
-     * @private
-     * @returns {void}
-     */
+    /**
+       * Capture frame from camera and copy data to canvas.
+       * @private
+       * @returns {void}
+       */
     captureFrame() {
         let detected = detectBrowser();
         let recordCanvas = this.player.recordCanvas.el().firstChild;
@@ -1601,7 +1601,7 @@ class Record extends Plugin {
             // importing ImageCapture can fail when enabling chrome flag is still required.
             // if so; ignore and continue
             if ((detected.browser === 'chrome' && detected.version >= 60) &&
-               (typeof ImageCapture === typeof Function)) {
+                (typeof ImageCapture === typeof Function)) {
                 try {
                     let track = this.stream.getVideoTracks()[0];
                     let imageCapture = new ImageCapture(track);
@@ -1627,11 +1627,11 @@ class Record extends Plugin {
         });
     }
 
-        /**
-     * Capture frame from camera and copy data to canvas.
-     * @private
-     * @returns {void}
-     */
+    /**
+ * Capture frame from camera and copy data to canvas.
+ * @private
+ * @returns {void}
+ */
     captureCameraFrame() {
         let detected = detectBrowser();
         let recordCanvas = this.player.recordCanvas.el().firstChild;
@@ -1648,21 +1648,21 @@ class Record extends Plugin {
             //
             // importing ImageCapture can fail when enabling chrome flag is still required.
             // if so; ignore and continue
-      
-            var originalImageCanvas = document.createElement('canvas');
+            const originalImageCanvas = document.createElement('canvas');
 
             originalImageCanvas.width = this.cameraFeedWidth;
             originalImageCanvas.height = this.cameraFeedHeight;
 
-            var cameraAspectRatio = this.cameraFeedWidth/this.cameraFeedHeight;
-            var playerAspectRatio = this.player.width()/this.player.height();
+            const cameraAspectRatio = this.cameraFeedWidth / this.cameraFeedHeight;
+            const playerAspectRatio = this.player.width() / this.player.height();
 
             let imagePreviewHeight = null;
             let imagePreviewWidth = null;
             let imageXPosition = null;
             let imageYPosition = null;
 
-            if(cameraAspectRatio >= playerAspectRatio) {
+            // buddy ignore:start
+            if (cameraAspectRatio >= playerAspectRatio) {
                 //image feed wider than player.
                 imagePreviewHeight = this.cameraFeedHeight * (this.player.width() / this.cameraFeedWidth);
                 imagePreviewWidth = this.player.width();
@@ -1670,11 +1670,12 @@ class Record extends Plugin {
                 imageYPosition = (this.player.height() / 2) - (imagePreviewHeight / 2);
             } else {
                 //player wider than image feed.
-                imagePreviewHeight = this.player.height()
+                imagePreviewHeight = this.player.height();
                 imagePreviewWidth = this.cameraFeedWidth * (this.player.height() / this.cameraFeedHeight);
                 imageXPosition = (this.player.width() / 2) - (imagePreviewWidth / 2);
                 imageYPosition = 0;
             }
+            // buddy ignore:end
 
             if ((detected.browser === 'chrome' && detected.version >= 60) &&
                 (typeof ImageCapture === typeof Function)) {
@@ -1685,35 +1686,33 @@ class Record extends Plugin {
 
                     // take picture
                     imageCapture.takePhoto().then((imageBlob) => {
-            
-                            recordCanvas.width = this.player.width();
-                            recordCanvas.height = this.player.height();
-            
-                            var originalImageBlobURL = URL.createObjectURL(imageBlob);
-                            var imageToResolve = new Image();
-            
-                            imageToResolve.onload = () => {
 
-                                originalImageCanvas.getContext('2d').drawImage(this.mediaElement, 0, 0);
-            
-                                this.drawCanvas(recordCanvas, imageToResolve, imageXPosition, imageYPosition, imagePreviewWidth, imagePreviewHeight);
-            
-                                //Cleanup
-                                URL.revokeObjectURL(originalImageBlobURL);
-                                imageToResolve.onload = null;
-                                imageToResolve = null;
-            
-                                //Resolve with original captured image at full resolution.
-                                resolve(originalImageCanvas);
-                            };
-            
-                            imageToResolve.src = originalImageBlobURL;
+                        recordCanvas.width = this.player.width();
+                        recordCanvas.height = this.player.height();
+
+                        let originalImageBlobURL = URL.createObjectURL(imageBlob);
+                        let imageToResolve = new Image();
+
+                        imageToResolve.onload = () => {
+
+                            originalImageCanvas.getContext('2d').drawImage(this.mediaElement, 0, 0);
+
+                            this.drawCanvas(recordCanvas, imageToResolve, imageXPosition, imageYPosition, imagePreviewWidth, imagePreviewHeight);
+
+                            //Cleanup
+                            URL.revokeObjectURL(originalImageBlobURL);
+                            imageToResolve.onload = null;
+                            imageToResolve = null;
+
+                            //Resolve with original captured image at full resolution.
+                            resolve(originalImageCanvas);
+                        };
+
+                        imageToResolve.src = originalImageBlobURL;
                     }).catch((error) => {
-                        console.log(error);
                         // ignore, try oldskool
                     });
                 } catch (err) {
-                    console.log(error);
                 }
             }
             // no ImageCapture available: do it the oldskool way
@@ -1727,8 +1726,8 @@ class Record extends Plugin {
                 recordCanvas.width = this.player.width();
                 recordCanvas.height = this.player.height();
 
-                var originalImageBlobURL = URL.createObjectURL(imageBlob);
-                var imageToResolve = new Image();
+                let originalImageBlobURL = URL.createObjectURL(imageBlob);
+                let imageToResolve = new Image();
 
                 imageToResolve.onload = () => {
                     this.drawCanvas(recordCanvas, imageToResolve, imageXPosition, imageYPosition, imagePreviewWidth, imagePreviewHeight);

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -21,10 +21,10 @@ import pluginDefaultOptions from './defaults';
 import formatTime from './utils/format-time';
 import setSrcObject from './utils/browser-shim';
 import compareVersion from './utils/compare-version';
-import { detectBrowser } from './utils/detect-browser';
+import {detectBrowser} from './utils/detect-browser';
 
-import { getAudioEngine, isAudioPluginActive, getVideoEngine, getConvertEngine } from './engine/engine-loader';
-import { IMAGE_ONLY, AUDIO_ONLY, VIDEO_ONLY, AUDIO_VIDEO, AUDIO_SCREEN, ANIMATION, SCREEN_ONLY, getRecorderMode } from './engine/record-mode';
+import {getAudioEngine, isAudioPluginActive, getVideoEngine, getConvertEngine} from './engine/engine-loader';
+import {IMAGE_ONLY, AUDIO_ONLY, VIDEO_ONLY, AUDIO_VIDEO, AUDIO_SCREEN, ANIMATION, SCREEN_ONLY, getRecorderMode} from './engine/record-mode';
 
 const Plugin = videojs.getPlugin('plugin');
 const Player = videojs.getComponent('Player');
@@ -52,7 +52,7 @@ class Record extends Plugin {
             let retval = this.techGet_('play');
             // silence errors (unhandled promise from play)
             if (retval !== undefined && typeof retval.then === 'function') {
-                retval.then(null, (e) => { });
+                retval.then(null, (e) => {});
             }
             return retval;
         };
@@ -863,10 +863,6 @@ class Record extends Plugin {
                     // for animations, capture the first frame
                     // that can be displayed as soon as recording
                     // is complete
-
-                    this.cameraFeedWidth = this.mediaElement.offsetWidth;
-                    this.cameraFeedHeight = this.mediaElement.offsetHeight;
-
                     this.captureFrame().then((result) => {
                         // start video preview **after** capturing first frame
                         this.startVideoPreview();
@@ -1541,7 +1537,6 @@ class Record extends Plugin {
 
                     // display the snapshot
                     this.displaySnapshot();
-
                 });
             } else if (this.imageOutputType === 'dataURL') {
                 // turn the canvas data into base64 data
@@ -1895,12 +1890,12 @@ class Record extends Plugin {
     setVideoInput(deviceId) {
         if (this.recordVideo === Object(this.recordVideo)) {
             // already using video constraints
-            this.recordVideo.deviceId = { exact: deviceId };
+            this.recordVideo.deviceId = {exact: deviceId};
 
         } else if (this.recordVideo === true) {
             // not using video constraints already, so force it
             this.recordVideo = {
-                deviceId: { exact: deviceId }
+                deviceId: {exact: deviceId}
             };
         }
 
@@ -1919,12 +1914,12 @@ class Record extends Plugin {
     setAudioInput(deviceId) {
         if (this.recordAudio === Object(this.recordAudio)) {
             // already using audio constraints
-            this.recordAudio.deviceId = { exact: deviceId };
+            this.recordAudio.deviceId = {exact: deviceId};
 
         } else if (this.recordAudio === true) {
             // not using audio constraints already, so force it
             this.recordAudio = {
-                deviceId: { exact: deviceId }
+                deviceId: {exact: deviceId}
             };
         }
 
@@ -2015,14 +2010,9 @@ class Record extends Plugin {
         // only listen for this once; remove listener
         this.mediaElement.removeEventListener(Event.PLAYING, this.streamVisibleCallback);
 
-        console.log(`onStreamVisible(e) called: ${event}`);
-        console.log(event);
-
+        //captures the dimensions of the camera image.
         this.cameraFeedWidth = event.target.videoWidth;
         this.cameraFeedHeight = event.target.videoHeight;
-
-        console.log(`this.cameraFeedWidth: ${this.cameraFeedWidth}`);
-        console.log(`this.cameraFeedWidth: ${this.cameraFeedHeight}`);
 
         // reset and show camera button
         this.player.cameraButton.onStop();
@@ -2060,4 +2050,4 @@ if (videojs.getPlugin('record') === undefined) {
 }
 
 // export plugin
-export { Record };
+export {Record};

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -1703,22 +1703,14 @@ class Record extends Plugin {
                 } catch (err) {
                 }
             } else {
+                // no ImageCapture available: do it the oldskool way
+                // get a frame and copy it onto the canvas
                 originalImageCanvas.getContext('2d').drawImage(this.mediaElement, 0, 0);
+                this.drawCanvas(recordCanvas, originalImageCanvas, imageXPosition, imageYPosition, imagePreviewWidth, imagePreviewHeight);
 
-                let imageToResolve = new Image();
-                imageToResolve.onload = () => {
-                    this.drawCanvas(recordCanvas, imageToResolve, imageXPosition, imageYPosition, imagePreviewWidth, imagePreviewHeight);
-                    imageToResolve.onload = null;
-                    resolve(originalImageCanvas);
-                };
-
-                originalImageCanvas.toBlob((imageBlob) => {
-                    const originalImageBlobURL = URL.createObjectURL(imageBlob);
-                    imageToResolve.src = originalImageBlobURL;
-                });
+                resolve(originalImageCanvas);
             }
-            // no ImageCapture available: do it the oldskool way
-            // get a frame and copy it onto the canvas
+
 
         });
     }

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -1708,7 +1708,6 @@ class Record extends Plugin {
                 let imageToResolve = new Image();
                 imageToResolve.onload = () => {
                     this.drawCanvas(recordCanvas, imageToResolve, imageXPosition, imageYPosition, imagePreviewWidth, imagePreviewHeight);
-    
                     imageToResolve.onload = null;
                     resolve(originalImageCanvas);
                 };


### PR DESCRIPTION
Hi @thijstriemstra,

I've had a go at putting together a fix for the following issue that I opened some weeks ago:

#511 - IMAGE_ONLY mode - can't specify camera resolution and stretched output. 

I have created a method captureCameraFrame() that draws the full resolution image onto a different canvas from recordCanvas and resolves that. The image is also drawn onto recordCanvas scaled to fit the image to the player for preview purposes. The aspect ratio of the image is maintained.

I opted to not edit the existing captureFrame() method because it was unclear what interaction that has with ANIMATION_ONLY mode. Incidentally, the preview in ANIMATION_ONLY mode does not work in my local code or the online demos.

If you have any amendments, feedback or further comments, I would love to hear them.

Kind Regards,
John