### PR TITLE
Stop screensharing on microphone permissions error in AUDIO_SCREEN mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   to control start of converter process (#568)
 - Improve check in `removeRecording` (#575)
 - Bump required version for webrtc-adapter (8.0.0 or newer)
+- Stop screen sharing on a microphone permissions error in the AUDIO_SCREEN mode (#585)
 
 
 ## 4.4.0 - 2021/04/05

--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -535,9 +535,14 @@ class Record extends Plugin {
                         // join microphone track with screencast stream (order matters)
                         screenStream.addTrack(mic.getTracks()[0]);
                         this.onDeviceReady.bind(this)(screenStream);
-                    }).catch(
-                        this.onDeviceError.bind(this)
-                    );
+                    }).catch((code) => {
+                        // here the screen sharing is in progress as successful result of navigator.mediaDevices.getDisplayMedia and
+                        // needs to be stopped because microphone permissions are not acquired by navigator.mediaDevices.getUserMedia
+                        if (screenStream.active) {
+                            screenStream.stop();
+                        }
+                        this.onDeviceError(code);
+                    });
                 }).catch(
                     this.onDeviceError.bind(this)
                 );


### PR DESCRIPTION
WHEN the AUDIO_SCREEN mode is selected
AND screen sharing is allowed
AND microphone is NOT allowed
THEN screen sharing continues despite the fact that "device error" event is triggered (not "device ready")

Expected: screen sharing stream is closed and the device error event is triggered
