### PR TITLE
Fix Record#setAudioOutput for non Audio only players

### DIFF
--- a/src/js/videojs.record.js
+++ b/src/js/videojs.record.js
@@ -1897,7 +1897,7 @@ class Record extends Plugin {
                 break;
 
             default:
-                let element = player.tech_.el_;
+                let element = this.player.tech_.el_;
                 if (deviceId) {
                     if (typeof element.sinkId !== 'undefined') {
                         element.setSinkId(deviceId).then((result) => {

--- a/test/videojs.record.spec.js
+++ b/test/videojs.record.spec.js
@@ -481,6 +481,27 @@ describe('Record', () => {
         });
     });
 
+    /** @test {Record#setAudioOutput} */
+    it('can set audio output for video player', (done) => {
+        // create new audio-video player
+        let player = TestHelpers.makeAudioVideoPlayer();
+
+        player.one(Event.ERROR, (e) => {
+            expect(e.type).toEqual(Event.ERROR);
+
+            done();
+        });
+
+        player.one(Event.ENUMERATE_READY, () => {
+            player.record().setAudioOutput('fakeId');
+        });
+
+        player.one(Event.READY, () => {
+            player.record().enumerateDevices();
+        });
+    });
+
+
     /** @test {Record#saveAs} */
     it('saves as', (done) => {
         // create new player


### PR DESCRIPTION
#fixes #732 

The `setAudioInput` method raises "player is not defined" exception when used in a mode different from the AUDIO_ONLY one. 

This PR fixes the problem by replacing the call to a global (and not always defined) `player.tech_.el_` call with `this.player.tech_.el_`.